### PR TITLE
Replace address-like thread names with a common value

### DIFF
--- a/ProfileWriter.cs
+++ b/ProfileWriter.cs
@@ -114,7 +114,7 @@ namespace EtwToPprof
         }
         string processName = sample.Process.ImageName;
         string threadLabel = sample.Thread?.Name;
-        if (threadLabel == null || threadLabel == "")
+        if (threadLabel == null || threadLabel == "" || threadLabel.StartsWith("0x"))
           threadLabel = "anonymous thread";
         if (options.includeProcessAndThreadIds)
         {


### PR DESCRIPTION
Sometimes threads get named like "0xdd000001", "0xdd000002", and these names don't persist across runs. This makes comparing pprofs difficult.
